### PR TITLE
Add baseurl property to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "baseurl": "/site",
   "site": {
     "name": "UPATCH Blog",
     "base_url": "https://vladchat.github.io/site/",


### PR DESCRIPTION
## Summary
- add a top-level `baseurl` property pointing to `/site` for GitHub Pages compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80e7ff8308332a5c3f42131b8e4c4