### PR TITLE
Update post rendering to use baseurl-aware context

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -133,33 +133,39 @@ def render_post(title, html_body, date, description):
     layout = (TEMPLATES / "layout.html").read_text(encoding="utf-8")
     post_tpl = (TEMPLATES / "post.html").read_text(encoding="utf-8")
     head_meta = (TEMPLATES / "partials" / "head-meta.html").read_text(encoding="utf-8")
-    related = (TEMPLATES / "partials" / "related.html").read_text(encoding="utf-8")
-    faq = (TEMPLATES / "partials" / "faq.html").read_text(encoding="utf-8")
 
-    # Estimate reading time ~200 wpm
-    words = len(re.sub(r"<[^>]+>", " ", html_body).split())
-    minutes = max(1, int(words / 200))
-    reading_time = f"~{minutes} min read"
+    baseurl = (CONFIG.get("baseurl") or "").rstrip("/")
 
-    # Fill post template
+    # Fill post template with the new context keys
     post_html = Template(post_tpl).render(
-        POST_TITLE=title, DATE=date.strftime("%B %d, %Y"), READING_TIME=reading_time,
-        POST_BODY=html_body, RELATED=related, FAQ=faq
+        title=title,
+        date=date.strftime("%B %d, %Y"),
+        content=html_body,
+        baseurl=baseurl,
     )
 
     canonical = f"{CONFIG['site']['base_url'].rstrip('/')}/posts/{date:%Y/%m/%d}/{slugify(title)}.html"
     head_filled = Template(head_meta).render(
-        TITLE=title, DESCRIPTION=description, PUBLISHED_ISO=date.isoformat(), UPDATED_ISO=date.isoformat(),
-        BYLINE=CONFIG['site'].get('brand_byline',''), SITE_NAME=CONFIG['site'].get('name',''),
-        CANONICAL=canonical
+        TITLE=title,
+        DESCRIPTION=description,
+        PUBLISHED_ISO=date.isoformat(),
+        UPDATED_ISO=date.isoformat(),
+        BYLINE=CONFIG['site'].get('brand_byline', ''),
+        SITE_NAME=CONFIG['site'].get('name', ''),
+        CANONICAL=canonical,
+        baseurl=baseurl,
     )
 
     # Fill layout
     final_html = Template(layout).render(
-        LANG=CONFIG['site'].get('language','en'),
-        TITLE=title, DESCRIPTION=description, HEAD_META=head_filled,
-        SITE_NAME=CONFIG['site'].get('name','Vlad’s Blog'), BYLINE=CONFIG['site'].get('brand_byline',''),
-        CONTENT=post_html
+        LANG=CONFIG['site'].get('language', 'en'),
+        TITLE=title,
+        DESCRIPTION=description,
+        HEAD_META=head_filled,
+        SITE_NAME=CONFIG['site'].get('name', 'Vlad’s Blog'),
+        BYLINE=CONFIG['site'].get('brand_byline', ''),
+        CONTENT=post_html,
+        baseurl=baseurl,
     )
     return final_html
 

--- a/templates/partials/head-meta.html
+++ b/templates/partials/head-meta.html
@@ -2,7 +2,7 @@
 <meta property="og:title" content="{{TITLE}}">
 <meta property="og:description" content="{{DESCRIPTION}}">
 <meta property="og:type" content="article">
-<meta property="og:image" content="/assets/og-default.png">
+<meta property="og:image" content="{{ baseurl }}/assets/og-default.png">
 <meta property="og:url" content="{{CANONICAL}}">
 <meta name="twitter:card" content="summary_large_image">
 <script type="application/ld+json">

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,16 +1,6 @@
-<!-- Post template is injected into layout.html -->
 <article>
-  <h1>{{POST_TITLE}}</h1>
-  <div class="meta">
-    <span>{{DATE}}</span> • <span class="reading-time">{{READING_TIME}}</span>
-  </div>
-
-  <div class="ad-slot" data-ad="slot2"></div>
-
-  {{POST_BODY}}
-
-  <div class="ad-slot" data-ad="slot3"></div>
-
-  {{RELATED}}
-  {{FAQ}}
+  <h1>{{ title }}</h1>
+  <p><em>{{ date }}</em></p>
+  <div>{{ content | safe }}</div>
+  <a href="{{ baseurl }}/index.html">Back to Home</a>
 </article>


### PR DESCRIPTION
## Summary
- refactor the post template to render the new title/date/content structure with a home link
- update the generator to pass the required context keys and base URL to post, layout, and head metadata templates
- adjust the head metadata asset reference to respect the configured base URL

## Testing
- python -m compileall generate.py

------
https://chatgpt.com/codex/tasks/task_e_68d814454a688332ac7fd4063289a4f0