### PR TITLE
Switch generator to a shared Jinja environment

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>404 — Not Found</h1><p>The page you are looking for does not exist.</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/site/assets/style.css'><div class='container'><h1>404 — Not Found</h1><p>The page you are looking for does not exist.</p></div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Vlad’s Blog — Home</title>
 <meta content="Latest automated articles." name="description"/>
-<link href="{{ baseurl }}/assets/style.css" rel="stylesheet"/>
+<link href="/site/assets/style.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="container">
@@ -14,16 +14,16 @@
 <div class="brand container">
 <div><strong>Vlad’s Blog</strong></div>
 <nav>
-<a href="{{ baseurl }}/">Home</a>
-<a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
-<a href="{{ baseurl }}/search.html">Search</a>
+<a href="/site/">Home</a>
+<a href="/site/feeds/rss.xml">RSS</a>
+<a href="/site/search.html">Search</a>
 </nav>
 </div>
 </header>
 <main>
 <div>
 <!-- Rendered list by rebuild_index.py -->
-<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="{{ baseurl }}/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
+<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="/site/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
 </div>
 <aside>
 <div class="widget">
@@ -39,12 +39,12 @@
 <footer>
 <div class="container">
 <p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
-<p><a href="{{ baseurl }}/privacy.html">Privacy</a> · <a href="{{ baseurl }}/terms.html">Terms</a></p>
+<p><a href="/site/privacy.html">Privacy</a> · <a href="/site/terms.html">Terms</a></p>
 </div>
 </footer>
 </div>
 <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-<script defer="" src="{{ baseurl }}/assets/ad-loader.js"></script>
-<script defer="" src="{{ baseurl }}/assets/search.js"></script>
+<script defer="" src="/site/assets/ad-loader.js"></script>
+<script defer="" src="/site/assets/search.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Privacy Policy</h1><p>...</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/site/assets/style.css'><div class='container'><h1>Privacy Policy</h1><p>...</p></div>

--- a/search.html
+++ b/search.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search — Vlad’s Blog</title>
-  <link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
+  <link rel="stylesheet" href="/site/assets/style.css">
 </head>
 <body>
   <div class="container">
@@ -12,9 +12,9 @@
       <div class="brand container">
         <div><strong>Vlad’s Blog</strong></div>
         <nav>
-          <a href="{{ baseurl }}/">Home</a>
-          <a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
-          <a href="{{ baseurl }}/search.html">Search</a>
+          <a href="/site/">Home</a>
+          <a href="/site/feeds/rss.xml">RSS</a>
+          <a href="/site/search.html">Search</a>
         </nav>
       </div>
     </header>
@@ -32,6 +32,6 @@
     </footer>
   </div>
   <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-  <script src="{{ baseurl }}/assets/search.js" defer></script>
+  <script src="/site/assets/search.js" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Terms of Service</h1><p>...</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/site/assets/style.css'><div class='container'><h1>Terms of Service</h1><p>...</p></div>


### PR DESCRIPTION
## Summary
- instantiate a shared Jinja2 environment with loaders for the project root and templates, exposing shared metadata to every render
- refactor post rendering to use environment-backed templates and add helpers that regenerate the index and static pages on each run
- update the committed HTML outputs so published pages no longer contain raw Jinja placeholders

## Testing
- python generate.py --auto

------
https://chatgpt.com/codex/tasks/task_e_68d8143bee4083328171edc52b2960d2