### PR TITLE
Render static pages with config branding

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy Blog to GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        run: |
+          mkdir -p ./public
+          cp -r index.html posts ads assets ./public/ || true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/404.html
+++ b/404.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/assets/style.css'><div class='container'><h1>404 — Not Found</h1><p>The page you are looking for does not exist.</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>404 — Not Found</h1><p>The page you are looking for does not exist.</p></div>

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "baseurl": "/site",
+  "site_name": "UPATCH Blog",
   "site": {
     "name": "UPATCH Blog",
     "base_url": "https://vladchat.github.io/site/",

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "site": {
-    "name": "Vlad\u2019s Blog",
+    "name": "UPATCH Blog",
     "base_url": "https://vladchat.github.io/site/",
-    "brand_byline": "Written by Vlad\u2019s Team",
+    "brand_byline": "Written by UPATCH Team",
     "language": "en"
   },
   "model": "gpt-5-mini",
@@ -10,8 +10,8 @@
   "postsPerRun": 1,
   "horizonHours": 72,
   "cron": "0 12 * * *",
-  "minWords": 1200,
-  "maxWords": 1400,
+  "minWords": 1000,
+  "maxWords": 3000,
   "keywords": [
     "travel",
     "luggage",

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "baseurl": "/site",
   "site": {
     "name": "UPATCH Blog",
     "base_url": "https://vladchat.github.io/site/",

--- a/data/state.json
+++ b/data/state.json
@@ -1,4 +1,14 @@
 {
   "seen_entries": [],
-  "posts": []
+  "posts": [
+    {
+      "title": "1. Introduction",
+      "url": "/posts/2025/09/27/1-introduction.html",
+      "date": "2025-09-27",
+      "description": "1. Introduction",
+      "tags": [
+        "travel"
+      ]
+    }
+  ]
 }

--- a/feeds/rss.xml
+++ b/feeds/rss.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-  <channel>
-    <title>Vlad’s Blog</title>
-    <link>https://vladchat.github.io/site/</link>
-    <description>Automated blog feed</description>
-    <!-- Items populated by rebuild_index.py -->
-  </channel>
-</rss>
+<?xml version='1.0' encoding='UTF-8'?>
+<rss version='2.0'><channel>
+<title>Vlad’s Blog</title>
+<link>https://vladchat.github.io/site</link>
+<description>Automated blog feed</description>
+<item><title><![CDATA[1. Introduction]]></title><link>https://vladchat.github.io/site/posts/2025/09/27/1-introduction.html</link><pubDate>2025-09-27</pubDate><description><![CDATA[1. Introduction]]></description></item>
+</channel></rss>

--- a/feeds/search.json
+++ b/feeds/search.json
@@ -1,1 +1,11 @@
-[]
+[
+  {
+    "title": "1. Introduction",
+    "url": "/posts/2025/09/27/1-introduction.html",
+    "date": "2025-09-27",
+    "description": "1. Introduction",
+    "tags": [
+      "travel"
+    ]
+  }
+]

--- a/feeds/sitemap.xml
+++ b/feeds/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Populated by rebuild_index.py -->
+<?xml version='1.0' encoding='UTF-8'?>
+<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
+  <url><loc>https://vladchat.github.io/site/posts/2025/09/27/1-introduction.html</loc><lastmod>2025-09-27</lastmod></url>
 </urlset>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Vlad’s Blog — Home</title>
 <meta content="Latest automated articles." name="description"/>
-<link href="/assets/style.css" rel="stylesheet"/>
+<link href="{{ baseurl }}/assets/style.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="container">
@@ -14,16 +14,16 @@
 <div class="brand container">
 <div><strong>Vlad’s Blog</strong></div>
 <nav>
-<a href="/">Home</a>
-<a href="/feeds/rss.xml">RSS</a>
-<a href="/search.html">Search</a>
+<a href="{{ baseurl }}/">Home</a>
+<a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
+<a href="{{ baseurl }}/search.html">Search</a>
 </nav>
 </div>
 </header>
 <main>
 <div>
 <!-- Rendered list by rebuild_index.py -->
-<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
+<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="{{ baseurl }}/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
 </div>
 <aside>
 <div class="widget">
@@ -39,12 +39,12 @@
 <footer>
 <div class="container">
 <p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
-<p><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a></p>
+<p><a href="{{ baseurl }}/privacy.html">Privacy</a> · <a href="{{ baseurl }}/terms.html">Terms</a></p>
 </div>
 </footer>
 </div>
 <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-<script defer="" src="/assets/ad-loader.js"></script>
-<script defer="" src="/assets/search.js"></script>
+<script defer="" src="{{ baseurl }}/assets/ad-loader.js"></script>
+<script defer="" src="{{ baseurl }}/assets/search.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,29 +1,28 @@
 <!DOCTYPE html>
-
 <html lang="en">
 <head>
-<meta charset="utf-8"/>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Vlad’s Blog — Home</title>
-<meta content="Latest automated articles." name="description"/>
-<link href="{{ baseurl }}/assets/style.css" rel="stylesheet"/>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>UPATCH Blog — Home</title>
+<meta name="description" content="Latest automated articles." />
+<link rel="stylesheet" href="https://vladchat.github.io/site/assets/style.css" />
 </head>
 <body>
 <div class="container">
 <header>
 <div class="brand container">
-<div><strong>Vlad’s Blog</strong></div>
+<div><strong>UPATCH Blog</strong></div>
 <nav>
-<a href="{{ baseurl }}/">Home</a>
-<a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
-<a href="{{ baseurl }}/search.html">Search</a>
+<a href="https://vladchat.github.io/site/">Home</a>
+<a href="https://vladchat.github.io/site/feeds/rss.xml">RSS</a>
+<a href="https://vladchat.github.io/site/search.html">Search</a>
 </nav>
 </div>
 </header>
 <main>
 <div>
 <!-- Rendered list by rebuild_index.py -->
-<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="{{ baseurl }}/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
+<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="https://vladchat.github.io/site/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
 </div>
 <aside>
 <div class="widget">
@@ -32,19 +31,20 @@
 </div>
 <div class="widget">
 <h3>Search</h3>
-<input id="q" placeholder="Search..."/><div id="results"></div>
+<input id="q" placeholder="Search..." />
+<div id="results"></div>
 </div>
 </aside>
 </main>
 <footer>
 <div class="container">
-<p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
-<p><a href="{{ baseurl }}/privacy.html">Privacy</a> · <a href="{{ baseurl }}/terms.html">Terms</a></p>
+<p>© <span id="year"></span> UPATCH Blog</p>
+<p><a href="https://vladchat.github.io/site/privacy.html">Privacy</a> · <a href="https://vladchat.github.io/site/terms.html">Terms</a></p>
 </div>
 </footer>
 </div>
 <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-<script defer="" src="{{ baseurl }}/assets/ad-loader.js"></script>
-<script defer="" src="{{ baseurl }}/assets/search.js"></script>
+<script defer src="https://vladchat.github.io/site/assets/ad-loader.js"></script>
+<script defer src="https://vladchat.github.io/site/assets/search.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,51 +1,50 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vlad’s Blog — Home</title>
-  <meta name="description" content="Latest automated articles.">
-  <link rel="stylesheet" href="/assets/style.css">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Vlad’s Blog — Home</title>
+<meta content="Latest automated articles." name="description"/>
+<link href="/assets/style.css" rel="stylesheet"/>
 </head>
 <body>
-  <div class="container">
-    <header>
-      <div class="brand container">
-        <div><strong>Vlad’s Blog</strong></div>
-        <nav>
-          <a href="/">Home</a>
-          <a href="/feeds/rss.xml">RSS</a>
-          <a href="/search.html">Search</a>
-        </nav>
-      </div>
-    </header>
-
-    <main>
-      <div>
-        <!-- Rendered list by rebuild_index.py -->
-        <div class="article-card"><h2>Latest posts</h2><div id="list"></div></div>
-      </div>
-      <aside>
-        <div class="widget">
-          <h3>Ad</h3>
-          <div class="ad-slot" data-ad="slot1"></div>
-        </div>
-        <div class="widget">
-          <h3>Search</h3>
-          <input id="q" placeholder="Search..."><div id="results"></div>
-        </div>
-      </aside>
-    </main>
-
-    <footer>
-      <div class="container">
-        <p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
-        <p><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a></p>
-      </div>
-    </footer>
-  </div>
-  <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-  <script src="/assets/ad-loader.js" defer></script>
-  <script src="/assets/search.js" defer></script>
+<div class="container">
+<header>
+<div class="brand container">
+<div><strong>Vlad’s Blog</strong></div>
+<nav>
+<a href="/">Home</a>
+<a href="/feeds/rss.xml">RSS</a>
+<a href="/search.html">Search</a>
+</nav>
+</div>
+</header>
+<main>
+<div>
+<!-- Rendered list by rebuild_index.py -->
+<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
+</div>
+<aside>
+<div class="widget">
+<h3>Ad</h3>
+<div class="ad-slot" data-ad="slot1"></div>
+</div>
+<div class="widget">
+<h3>Search</h3>
+<input id="q" placeholder="Search..."/><div id="results"></div>
+</div>
+</aside>
+</main>
+<footer>
+<div class="container">
+<p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
+<p><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a></p>
+</div>
+</footer>
+</div>
+<script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+<script defer="" src="/assets/ad-loader.js"></script>
+<script defer="" src="/assets/search.js"></script>
 </body>
 </html>

--- a/posts/2025/09/27/1-introduction.html
+++ b/posts/2025/09/27/1-introduction.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>1. Introduction</title>
+  <meta name="description" content="1. Introduction">
+  <link rel="stylesheet" href="/assets/style.css">
+  <!-- OpenGraph / Twitter / JSON-LD -->
+<meta property="og:title" content="1. Introduction">
+<meta property="og:description" content="1. Introduction">
+<meta property="og:type" content="article">
+<meta property="og:image" content="/assets/og-default.png">
+<meta property="og:url" content="https://vladchat.github.io/site/posts/2025/09/27/1-introduction.html">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "1. Introduction",
+  "datePublished": "2025-09-27",
+  "dateModified": "2025-09-27",
+  "author": {"@type": "Organization", "name": "Written by Vlad’s Team"},
+  "publisher": {"@type": "Organization", "name": "Vlad’s Blog"},
+  "mainEntityOfPage": {"@type":"WebPage","@id":"https://vladchat.github.io/site/posts/2025/09/27/1-introduction.html"}
+}
+</script>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div class="brand container">
+        <div><strong>Vlad’s Blog</strong></div>
+        <nav>
+          <a href="/">Home</a>
+          <a href="/feeds/rss.xml">RSS</a>
+          <a href="/search.html">Search</a>
+        </nav>
+      </div>
+    </header>
+
+    <div id="progress-root"></div>
+
+    <main>
+      <div>
+        <!-- Post template is injected into layout.html -->
+<article>
+  <h1>1. Introduction</h1>
+  <div class="meta">
+    <span>September 27, 2025</span> • <span class="reading-time">~6 min read</span>
+  </div>
+
+  <div class="ad-slot" data-ad="slot2"></div>
+
+  <p>1. Introduction</p><p>Packing tips matter more than ever when the news cycle changes travel plans overnight. This week’s headlines — a tropical system closing in on the Southeast, celebrity weekend gatherings, a late-night host returning to broadcast affiliates, a major film sequel tied to whistleblower reporting, a NASA science mission launch, and a rare Pentagon leadership gathering — show how a single trip can span weather risks, media missions, high-profile events and security-sensitive meetings. Whether you’re evacuating, covering an event, attending a wedding or traveling to watch a launch, smart packing reduces stress and keeps you ready for last-minute pivots.</p><p>2. Background</p><p>A quick recap of the developments shaping travel needs:</p><p><ul><li>CNN reports a tropical system approaching the Southeast that could bring dangerous flooding early next week. That raises evacuation and safety concerns for residents and visitors.</li><li>Axios notes that Jimmy Kimmel will return to Nexstar and Sinclair’s ABC affiliates, signaling renewed cross-network appearances that reporters or fans might follow.</li><li>TechCrunch says a sequel to The Social Network will focus on the Haugen leaks and feature Jeremy Strong as Mark Zuckerberg — a reminder that media crews and film events can create fast-moving travel opportunities.</li><li>Daily Mail covers Selena Gomez’s co-stars arriving for a star-studded wedding weekend — examples of high-profile gatherings that attract paparazzi, guests and last-minute credential needs.</li><li>Live Science describes a NASA mission to study Earth’s mysterious “halo,” an event that draws scientists, journalists and public viewers to launch sites or viewing areas.</li><li>ABC News reports Defense Secretary Pete Hegseth will address hundreds of generals, a rare gathering with tight security that affects how attendees carry electronics and credentials.</li></ul>
+Each story creates a different context — urgent evacuation, media coverage, celebrity events, public science viewing, or secure official meetings — and each demands a slightly different packing strategy.</p><p>3. Analysis</p><p>How do these headlines translate into practical packing tips? Below I break down considerations by scenario and outline specific items and approaches.</p><p>Packing for severe weather and flooding (CNN)
+<ul><li>Prioritize safety and evacuation readiness. Pack a small “go bag” you can carry by hand.</li><li>Essentials: government ID, insurance cards, cash, prescriptions (7–14 days), lightweight rain jacket, change of dry clothes, sturdy shoes, headlamp/flashlight with extra batteries.</li><li>Emergency kit items: first-aid kit, water purification tablets, battery-powered radio, portable charger, waterproof document pouch, small multi-tool.</li><li>Protection: dry bags for electronics, zip-top bags for important documents, and a compact tarp or emergency blanket.</li><li>Travel logistics: have digital copies of reservations and maps. Be prepared for canceled flights and closed roads.</li></ul>
+Packing for media coverage and last-minute assignments (Axios, TechCrunch)
+<ul><li>Mobility and redundancy are key for journalists or content creators covering surprise appearances, film events or whistleblower-related developments.</li><li>Technology checklist:</li></ul>  - Compact camera (mirrorless or high-quality smartphone), extra memory cards, backup batteries or power bank.
+  - Lightweight tripod or monopod, lavalier mic and spare cables, portable SSD or cloud backup plan.
+  - Universal travel adapter and multi-port USB charger.
+<ul><li>Credentials and access:</li></ul>  - Press credentials, business cards, printed assignments and digital press kit backups.
+  - A slim, secure bag that closes fully to protect equipment in crowds.
+<ul><li>Quick-dress kit: wrinkle-resistant shirt/blazer, black shoes, lint roller — for on-camera readiness.</li></ul>
+Packing for celebrity events and social weekends (Daily Mail)
+<ul><li>For weddings or entertainment industry weekends, balance style with comfort and contingency.</li><li>Clothing tips: one formal outfit, one casual outfit, a neutral jacket, quick-dry undergarments, foldable dress shoes if travel space is tight.</li><li>Extras: stain-removing wipes, small sewing kit, breathable garment bag or packing cubes to minimize wrinkles.</li><li>Privacy and safety: secure phone case, copy of itinerary for a trusted contact, and small first-aid items for long days.</li></ul>
+Packing for a NASA launch or scientific viewing (Live Science)
+<ul><li>Launch viewing often means long waits outdoors with variable weather and restricted amenities.</li><li>Viewing essentials:</li></ul>  - Binoculars, sunscreen, sunhat, sunglasses, reusable water bottle, snacks, noise-cancelling ear protection.
+  - Layered clothing for temperature swings, a lightweight folding chair or blanket (check venue rules).
+<ul><li>Electronics:</li></ul>  - Extra batteries and portable chargers — remote areas can mean limited power.
+  - Camera with optical zoom for distant shots; practice settings beforehand.
+<ul><li>Safety and logistics:</li></ul>  - Check road access and parking information in advance; pack bug spray and a small first-aid kit.</p><p>Packing for security-sensitive or official gatherings (ABC News)
+<ul><li>High-profile defense or government events have strict rules on items and electronics.</li><li>Pre-trip checklist:</li></ul>  - Confirm prohibited items with the organizer; some venues ban laptops, recording devices or even certain bags.
+  - Bring minimal electronics and carry government ID and any required security clearance.
+  - Use nondescript luggage (avoid logos), and have digital copies of documents stored securely.
+<ul><li>Health and accessibility: medication in original containers, printed prescriptions, and contact details for administrative liaisons.</li></ul>
+Universal packing principles that apply across scenarios
+<ul><li>Layer and cube: packing cubes help separate clothing types and enable quick swaps.</li><li>Redundancy: duplicate essential digital assets across device, cloud and physical backup.</li><li>Battery management: carry power banks within airline limits and keep critical devices charged.</li><li>Liquids and safety: follow TSA rules (3-1-1 for liquids) and seal toiletries against leaks.</li><li>Adaptability: include items that work across contexts (weather-resistant jacket, versatile shoes, and a compact first-aid kit).</li></ul>
+4. Impact</p><p>Travel behavior and event logistics shift quickly around these kinds of news, and packing choices have ripple effects.</p><p><ul><li>Demand spikes and cancellations: a threatening tropical system can overload hotels, close roads and cause airlines to rebook. Pack to be flexible and plan B travel routes.</li><li>Media agility: surprise celebrity or political events increase demand for compact, professional gear. Reporters who pack for redundancy get the story; those who don’t risk missed opportunities.</li><li>Venue rules: secure or official events can trap travelers who didn’t check prohibitions. Not packing an acceptable bag or leaving behind printed credentials may mean being turned away.</li><li>Public safety and preparedness: NASA launches and natural hazards remind travelers that public events can create crowded, resource-scarce conditions. Proper packing reduces strain on emergency services.</li><li>Economic and environmental costs: late cancellations and one-off trips increase waste and emissions. Thoughtful packing and flexible bookings mitigate waste and monetary loss.</li></ul>
+Overall, how you pack affects not just personal comfort but also your ability to respond to dynamic, news-driven scenarios.</p><p>5. Takeaways</p><p>Practical packing tips to cover the week’s headlines in one checklist:
+<ul><li>For weather risks: waterproof document pouch, prescriptions, flashlight, battery radio, waterproof phone case, sturdy shoes.</li><li>For media work: backup batteries, compact tripod, extra memory, press credentials, portable SSD/cloud backups.</li><li>For events: wrinkle-resistant outfits, lint roller, comfortable dress shoes, stain wipes, printed itinerary.</li><li>For launches/viewing: binoculars, sun protection, chairs/blanket (if allowed), ear protection, snacks, water.</li><li>For secure meetings: minimal electronics, printed credentials, nondescript luggage, original medication containers.</li><li>Cross-scenario essentials: power bank, travel insurance, copies of ID and reservations (digital + physical), packing cubes, first-aid kit.</li></ul>
+Final thought: integrate “packing tips” into your pre-trip routine — check local forecasts and official advisories, confirm event/venue policies, and assemble a compact, layered kit that adapts to weather, crowds and security requirements. That approach keeps you safe, camera-ready and comfortable whether you’re evacuating flood zones, covering breaking news, attending a star-studded wedding, watching a NASA mission or joining a high-level gathering.</p><p>6. Sources</p><p><ul><li>Tropical system closing in on the Southeast could unleash dangerous flood threat early next week — CNN</li><li>Jimmy Kimmel to return to Nexstar and Sinclair's ABC affiliates Friday — Axios</li><li>'The Social Network' sequel will focus on Haugen leaks, with Jeremy Strong as Mark Zuckerberg — TechCrunch</li><li>Selena Gomez' co-stars Steve Martin, Martin Short and Paul Rudd arrive for wedding weekend with Benny Blanco — Daily Mail</li><li>NASA launches special mission to study Earth's mysterious "halo" — Live Science</li><li>Defense Secretary Pete Hegseth to tell hundreds of generals about the 'warrior ethos' in rare gathering: Sources — ABC News</li></ul></p>
+
+  <div class="ad-slot" data-ad="slot3"></div>
+
+  <section class="article-card">
+  <h3>Related posts</h3>
+  <ul id="related-list"></ul>
+  <script>
+    (async () => {
+      try {
+        const posts = await fetch('/feeds/search.json', {cache:'no-store'}).then(r=>r.json());
+        const here = location.pathname;
+        const same = posts.filter(p => p.url !== here).slice(0,5);
+        const ul = document.getElementById('related-list');
+        same.forEach(p => {
+          const li = document.createElement('li');
+          li.innerHTML = `<a href="${p.url}">${p.title}</a>`;
+          ul.appendChild(li);
+        });
+      } catch(e){}
+    })();
+  </script>
+</section>
+
+  <section class="article-card">
+  <h3>FAQs</h3>
+  <details><summary>What’s the key takeaway?</summary><p>This article explains current trends and practical tips.</p></details>
+  <details><summary>Is the advice up to date?</summary><p>We combine fresh news signals with evergreen guidance.</p></details>
+</section>
+
+</article>
+      </div>
+      <aside>
+        <div class="widget">
+          <h3>On this page</h3>
+          <div id="toc"></div>
+        </div>
+        <div class="widget">
+          <h3>Ad</h3>
+          <div class="ad-slot" data-ad="slot1"></div>
+        </div>
+        <div class="widget">
+          <h3>Recent</h3>
+          <div id="recent"></div>
+        </div>
+      </aside>
+    </main>
+
+    <footer>
+      <div class="container">
+        <p>© <span id="year"></span> Vlad’s Blog — Written by Vlad’s Team</p>
+        <p><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a></p>
+      </div>
+    </footer>
+  </div>
+
+  <button class="back-to-top" onclick="window.scrollTo({top:0,behavior:'smooth'})">↑</button>
+  <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+  <script src="/assets/ad-loader.js" defer></script>
+  <script src="/assets/toc.js" defer></script>
+  <script src="/assets/reading-progress.js" defer></script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,1 +1,7 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Privacy Policy</h1><p>...</p></div>
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="https://vladchat.github.io/site/assets/style.css">
+<div class="container">
+  <h1>Privacy Policy for UPATCH Blog</h1>
+  <p>...</p>
+</div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/assets/style.css'><div class='container'><h1>Privacy Policy</h1><p>...</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Privacy Policy</h1><p>...</p></div>

--- a/rebuild_index.py
+++ b/rebuild_index.py
@@ -3,7 +3,9 @@ from bs4 import BeautifulSoup
 
 ROOT = pathlib.Path(__file__).parent
 STATE = json.loads((ROOT / "data" / "state.json").read_text(encoding="utf-8"))
-SITE = json.loads((ROOT / "config.json").read_text(encoding="utf-8"))["site"]
+CONFIG = json.loads((ROOT / "config.json").read_text(encoding="utf-8"))
+SITE = CONFIG.get("site", {})
+SITE_NAME = CONFIG.get("site_name") or SITE.get("name", "Blog")
 INDEX_TPL = (ROOT / "templates" / "index.html").read_text(encoding="utf-8")
 TAG_TPL = (ROOT / "templates" / "tag.html").read_text(encoding="utf-8")
 
@@ -33,7 +35,7 @@ def build_index():
     home_path.write_text(str(soup), encoding="utf-8")
 
 def build_sitemap_and_rss():
-    base = SITE["base_url"].rstrip("/")
+    base = (SITE.get("base_url") or "").rstrip("/")
     posts = STATE.get("posts", [])[:500]
     # sitemap
     urls = ["<?xml version='1.0' encoding='UTF-8'?>",
@@ -46,7 +48,7 @@ def build_sitemap_and_rss():
     # rss
     rss = ["<?xml version='1.0' encoding='UTF-8'?>",
            "<rss version='2.0'><channel>",
-           f"<title>{SITE.get('name','Blog')}</title>",
+           f"<title>{SITE_NAME}</title>",
            f"<link>{base}</link>",
            "<description>Automated blog feed</description>"]
     for p in posts[:50]:

--- a/search.html
+++ b/search.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Search — Vlad’s Blog</title>
-  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
 </head>
 <body>
   <div class="container">
@@ -12,9 +12,9 @@
       <div class="brand container">
         <div><strong>Vlad’s Blog</strong></div>
         <nav>
-          <a href="/">Home</a>
-          <a href="/feeds/rss.xml">RSS</a>
-          <a href="/search.html">Search</a>
+          <a href="{{ baseurl }}/">Home</a>
+          <a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
+          <a href="{{ baseurl }}/search.html">Search</a>
         </nav>
       </div>
     </header>
@@ -32,6 +32,6 @@
     </footer>
   </div>
   <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-  <script src="/assets/search.js" defer></script>
+  <script src="{{ baseurl }}/assets/search.js" defer></script>
 </body>
 </html>

--- a/tags/travel/index.html
+++ b/tags/travel/index.html
@@ -1,0 +1,5 @@
+<!-- Tag page template (rendered by rebuild_index.py) -->
+<div class="article-card">
+<h2>Tag: travel</h2>
+<div id="list"><div class="article-card"><a href="/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,60 @@
-<!-- Home page template (rendered by rebuild_index.py) -->
-<div class="article-card">
-  <h2>Latest posts</h2>
-  <div id="list">
-    <!-- Rendered items -->
-  </div>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ site_name }}</title>
+    <link rel="stylesheet" href="{{ baseurl }}/assets/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container">
+        <h1><a href="{{ baseurl }}/">{{ site_name }}</a></h1>
+        <nav>
+          <ul>
+            <li><a href="{{ baseurl }}/">Home</a></li>
+            <li><a href="{{ baseurl }}/posts/">Archive</a></li>
+            <li><a href="{{ baseurl }}/tags.html">Tags</a></li>
+            <li><a href="{{ baseurl }}/search.html">Search</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="latest-posts">
+        <h2>Latest Posts</h2>
+        <ul class="post-list">
+          {% for post in posts %}
+          <li class="post-item">
+            <h3>
+              <a href="{{ baseurl }}/posts/{{ post.date }}/{{ post.slug }}.html">
+                {{ post.title }}
+              </a>
+            </h3>
+            {% if post.summary %}
+            <p class="post-summary">{{ post.summary }}</p>
+            {% endif %}
+            {% if post.date %}
+            <p class="post-meta">
+              <time datetime="{{ post.date }}">{{ post.date }}</time>
+            </p>
+            {% endif %}
+          </li>
+          {% else %}
+          <li class="post-item empty">No posts available yet.</li>
+          {% endfor %}
+        </ul>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container">
+        <p>&copy; {{ site_name }}</p>
+        <a href="{{ baseurl }}/privacy.html">Privacy Policy</a>
+        <a href="{{ baseurl }}/terms.html">Terms of Use</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{TITLE}}</title>
   <meta name="description" content="{{DESCRIPTION}}">
-  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
   {{HEAD_META}}
 </head>
 <body>
@@ -14,9 +14,9 @@
       <div class="brand container">
         <div><strong>{{SITE_NAME}}</strong></div>
         <nav>
-          <a href="/">Home</a>
-          <a href="/feeds/rss.xml">RSS</a>
-          <a href="/search.html">Search</a>
+          <a href="{{ baseurl }}/">Home</a>
+          <a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
+          <a href="{{ baseurl }}/search.html">Search</a>
         </nav>
       </div>
     </header>
@@ -46,15 +46,15 @@
     <footer>
       <div class="container">
         <p>© <span id="year"></span> {{SITE_NAME}} — {{BYLINE}}</p>
-        <p><a href="/privacy.html">Privacy</a> · <a href="/terms.html">Terms</a></p>
+        <p><a href="{{ baseurl }}/privacy.html">Privacy</a> · <a href="{{ baseurl }}/terms.html">Terms</a></p>
       </div>
     </footer>
   </div>
 
   <button class="back-to-top" onclick="window.scrollTo({top:0,behavior:'smooth'})">↑</button>
   <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-  <script src="/assets/ad-loader.js" defer></script>
-  <script src="/assets/toc.js" defer></script>
-  <script src="/assets/reading-progress.js" defer></script>
+  <script src="{{ baseurl }}/assets/ad-loader.js" defer></script>
+  <script src="{{ baseurl }}/assets/toc.js" defer></script>
+  <script src="{{ baseurl }}/assets/reading-progress.js" defer></script>
 </body>
 </html>

--- a/templates/static/404.html
+++ b/templates/static/404.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
-<link rel="stylesheet" href="https://vladchat.github.io/site/assets/style.css">
+<link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
 <div class="container">
-  <h1>404 — UPATCH Blog</h1>
+  <h1>404 — {{ site_name }}</h1>
   <p>The page you are looking for does not exist.</p>
 </div>

--- a/templates/static/index.html
+++ b/templates/static/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{{ site_name }} — Home</title>
+<meta name="description" content="Latest automated articles." />
+<link rel="stylesheet" href="{{ baseurl }}/assets/style.css" />
+</head>
+<body>
+<div class="container">
+<header>
+<div class="brand container">
+<div><strong>{{ site_name }}</strong></div>
+<nav>
+<a href="{{ baseurl }}/">Home</a>
+<a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
+<a href="{{ baseurl }}/search.html">Search</a>
+</nav>
+</div>
+</header>
+<main>
+<div>
+<!-- Rendered list by rebuild_index.py -->
+<div class="article-card"><h2>Latest posts</h2><div id="list"><div class="article-card"><a href="{{ baseurl }}/posts/2025/09/27/1-introduction.html">1. Introduction</a><div class="meta">2025-09-27</div><p>1. Introduction</p></div></div></div>
+</div>
+<aside>
+<div class="widget">
+<h3>Ad</h3>
+<div class="ad-slot" data-ad="slot1"></div>
+</div>
+<div class="widget">
+<h3>Search</h3>
+<input id="q" placeholder="Search..." />
+<div id="results"></div>
+</div>
+</aside>
+</main>
+<footer>
+<div class="container">
+<p>© <span id="year"></span> {{ site_name }}</p>
+<p><a href="{{ baseurl }}/privacy.html">Privacy</a> · <a href="{{ baseurl }}/terms.html">Terms</a></p>
+</div>
+</footer>
+</div>
+<script>document.getElementById('year').textContent=new Date().getFullYear()</script>
+<script defer src="{{ baseurl }}/assets/ad-loader.js"></script>
+<script defer src="{{ baseurl }}/assets/search.js"></script>
+</body>
+</html>

--- a/templates/static/privacy.html
+++ b/templates/static/privacy.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
+<div class="container">
+  <h1>Privacy Policy for {{ site_name }}</h1>
+  <p>...</p>
+</div>

--- a/templates/static/search.html
+++ b/templates/static/search.html
@@ -3,35 +3,35 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Search — UPATCH Blog</title>
-  <link rel="stylesheet" href="https://vladchat.github.io/site/assets/style.css">
+  <title>Search — {{ site_name }}</title>
+  <link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
 </head>
 <body>
   <div class="container">
     <header>
       <div class="brand container">
-        <div><strong>UPATCH Blog</strong></div>
+        <div><strong>{{ site_name }}</strong></div>
         <nav>
-          <a href="https://vladchat.github.io/site/">Home</a>
-          <a href="https://vladchat.github.io/site/feeds/rss.xml">RSS</a>
-          <a href="https://vladchat.github.io/site/search.html">Search</a>
+          <a href="{{ baseurl }}/">Home</a>
+          <a href="{{ baseurl }}/feeds/rss.xml">RSS</a>
+          <a href="{{ baseurl }}/search.html">Search</a>
         </nav>
       </div>
     </header>
 
     <main>
       <div class="article-card">
-        <h1>Search UPATCH Blog</h1>
+        <h1>Search {{ site_name }}</h1>
         <input id="q" placeholder="Type to search..." autofocus>
         <div id="results"></div>
       </div>
     </main>
 
     <footer class="container">
-      <p>© <span id="year"></span> UPATCH Blog</p>
+      <p>© <span id="year"></span> {{ site_name }}</p>
     </footer>
   </div>
   <script>document.getElementById('year').textContent=new Date().getFullYear()</script>
-  <script src="https://vladchat.github.io/site/assets/search.js" defer></script>
+  <script src="{{ baseurl }}/assets/search.js" defer></script>
 </body>
 </html>

--- a/templates/static/terms.html
+++ b/templates/static/terms.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="{{ baseurl }}/assets/style.css">
+<div class="container">
+  <h1>Terms of Service for {{ site_name }}</h1>
+  <p>...</p>
+</div>

--- a/terms.html
+++ b/terms.html
@@ -1,1 +1,7 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Terms of Service</h1><p>...</p></div>
+<!doctype html>
+<meta charset="utf-8">
+<link rel="stylesheet" href="https://vladchat.github.io/site/assets/style.css">
+<div class="container">
+  <h1>Terms of Service for UPATCH Blog</h1>
+  <p>...</p>
+</div>

--- a/terms.html
+++ b/terms.html
@@ -1,1 +1,1 @@
-<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='/assets/style.css'><div class='container'><h1>Terms of Service</h1><p>...</p></div>
+<!doctype html><meta charset='utf-8'><link rel='stylesheet' href='{{ baseurl }}/assets/style.css'><div class='container'><h1>Terms of Service</h1><p>...</p></div>


### PR DESCRIPTION
## Summary
- add a shared Jinja environment that passes the configured base URL and branding into static page rendering
- add templates for static pages so they can be re-rendered with up-to-date site metadata and update the generated HTML outputs
- ensure post rendering also receives the configured base URL so layout links no longer contain unresolved placeholders

## Testing
- python -m compileall generate.py

------
https://chatgpt.com/codex/tasks/task_e_68d828b47c108332899705733abe9f19