### PR TITLE
Update Pages workflow to include archive directories

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,21 @@ jobs:
       - name: Build site
         run: |
           mkdir -p ./public
-          cp -r *.html posts ads assets feeds data tags config ./public/ || true
+          rsync -av \
+            --exclude='public/***' \
+            --filter='+ /*.html' \
+            --filter='+ /robots.txt' \
+            --filter='+ /ads/***' \
+            --filter='+ /assets/***' \
+            --filter='+ /config/***' \
+            --filter='+ /data/***' \
+            --filter='+ /feeds/***' \
+            --filter='+ /page*/***' \
+            --filter='+ /posts/***' \
+            --filter='+ /tags/***' \
+            --filter='- /**' \
+            --filter='- **' \
+            ./ ./public/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- replace the GitHub Pages build copy step with an allow-listed `rsync`
- ensure archive directories such as `page/` (and any future `page*` folders) are published alongside existing content

## Testing
- `rsync -av --exclude='public/***' --filter='+ /*.html' --filter='+ /robots.txt' --filter='+ /ads/***' --filter='+ /assets/***' --filter='+ /config/***' --filter='+ /data/***' --filter='+ /feeds/***' --filter='+ /page*/***' --filter='+ /posts/***' --filter='+ /tags/***' --filter='- /**' --filter='- **' ./ ./public/`


------
https://chatgpt.com/codex/tasks/task_e_68d9713418f0833289a14bf38a5601f6