### PR TITLE
Fix prev pagination link for second page

### DIFF
--- a/data/state.json
+++ b/data/state.json
@@ -9,15 +9,6 @@
       "tags": [
         "travel"
       ]
-    },
-    {
-      "title": "# Introduction",
-      "url": "/posts/2025/09/27/introduction.html",
-      "date": "2025-09-27",
-      "description": "Introduction\nThis is demo content. Replace with OpenAI output.",
-      "tags": [
-        "travel"
-      ]
     }
   ]
 }

--- a/feeds/search.json
+++ b/feeds/search.json
@@ -7,14 +7,5 @@
     "tags": [
       "travel"
     ]
-  },
-  {
-    "title": "# Introduction",
-    "url": "/posts/2025/09/27/introduction.html",
-    "date": "2025-09-27",
-    "description": "Introduction\nThis is demo content. Replace with OpenAI output.",
-    "tags": [
-      "travel"
-    ]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <title>Vlad’s Blog — Home</title>
 <meta content="Latest automated articles." name="description"/>
 <link href="https://vladchat.github.io/site/assets/style.css" rel="stylesheet"/>
-<meta content="https://vladchat.github.io/site" name="site-base"/>
+<meta content="/site" name="site-base"/>
 </head>
 <body>
 <div class="container">
@@ -26,9 +26,8 @@
 <h2>Latest posts</h2>
 <div class="ad-slot" data-ad="slot1" id="slot1"></div>
 <!-- Rendered list by rebuild_index.py -->
-<div id="list"><div class="article-card"><a href="https://vladchat.github.io/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
-This is demo content. Replace with OpenAI output.</p></div><div class="article-card"><a href="https://vladchat.github.io/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
-This is demo content. Replace with OpenAI output.</p></div></div>
+<div id="list"><div class="article-card"><a href="/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
+This is demo content. Replace with OpenAI output.</p></div><div class="pagination"></div></div>
 </div>
 <aside>
 <div class="widget">

--- a/rebuild_index.py
+++ b/rebuild_index.py
@@ -94,7 +94,8 @@ def build_main_and_pages():
         # добавляем навигацию
         nav = soup.new_tag("div", attrs={"class": "pagination"})
         if page > 1:
-            prev_link = soup.new_tag("a", href=f"{BASE}/page/{page-1}/index.html")
+            prev_href = f"{BASE}/" if (page - 1) == 1 else f"{BASE}/page/{page-1}/index.html"
+            prev_link = soup.new_tag("a", href=prev_href)
             prev_link.string = "← Previous"
             nav.append(prev_link)
         if page < pages:

--- a/rss.xml
+++ b/rss.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>uPatch Blog</title>
+<link>https://vladchat.github.io/site/</link>
+<description>uPatch Blog</description>
+<item><title><![CDATA[# Introduction]]></title><link>https://vladchat.github.io/site/posts/2025/09/27/introduction.html</link><pubDate>Sat, 27 Sep 2025 00:00:00 -0000</pubDate><description><![CDATA[Introduction
+This is demo content. Replace with OpenAI output.]]></description></item>
+</channel></rss>

--- a/search.html
+++ b/search.html
@@ -6,7 +6,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Search — Vlad’s Blog</title>
 <link href="https://vladchat.github.io/site/assets/style.css" rel="stylesheet"/>
-<meta content="https://vladchat.github.io/site" name="site-base"/></head>
+<meta content="/site" name="site-base"/></head>
 <body>
 <div class="container">
 <header>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://vladchat.github.io/site/posts/2025/09/27/introduction.html</loc><lastmod>2025-09-27</lastmod></url>
+</urlset>

--- a/tags/travel/index.html
+++ b/tags/travel/index.html
@@ -1,7 +1,2 @@
-<!-- Tag page template (rendered by rebuild_index.py) -->
-<div class="article-card">
-<h2>Tag: travel</h2>
-<div id="list"><div class="article-card"><a href="https://vladchat.github.io/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
-This is demo content. Replace with OpenAI output.</p></div><div class="article-card"><a href="https://vladchat.github.io/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
-This is demo content. Replace with OpenAI output.</p></div></div>
-</div>
+<html><body><h1>Tag: travel</h1><div id="list"><div class="article-card"><a href="/site/posts/2025/09/27/introduction.html"># Introduction</a><div class="meta">2025-09-27</div><p>Introduction
+This is demo content. Replace with OpenAI output.</p></div></div></body></html>


### PR DESCRIPTION
## Summary
- adjust pagination builder so the page 2 "Previous" link points to the main index instead of the page/1 directory
- regenerate the static outputs to reflect the updated pagination logic and normalized state

## Testing
- python rebuild_index.py

------
https://chatgpt.com/codex/tasks/task_e_68d972dbb0d48332990f3508bfb21738