### PR TITLE
Add layout head placeholder for post metadata

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ site.name }}</title>
   <link rel="stylesheet" href="/site/assets/style.css">
+  {{ head_meta }}
 </head>
 <body>
   <header>

--- a/writer/render.py
+++ b/writer/render.py
@@ -74,4 +74,12 @@ def render_post_html(title, body_md, faq_html, faq_jsonld, configs, *, slug, pub
         .replace("{{SITE_NAME}}", site.get("name",""))
     ) + "\n" + faq_jsonld
 
-    return layout.replace("{{ site.name }}", site.get("name","")).replace("{{ content }}", head_filled + "\n" + content)
+    if "{{ head_meta }}" in layout:
+        layout = layout.replace("{{ head_meta }}", head_filled)
+    else:
+        layout = layout.replace("</head>", head_filled + "\n</head>")
+
+    layout = layout.replace("{{ site.name }}", site.get("name",""))
+    layout = layout.replace("{{ content }}", content)
+
+    return layout


### PR DESCRIPTION
## Summary
- add a reusable {{ head_meta }} placeholder inside the shared layout head
- populate the placeholder when rendering posts, falling back to </head> injection when absent
- keep the <main> block limited to article markup by removing the previous content prepending

## Testing
- python - <<'PY'
from writer.config import load_configs
from writer.render import render_post_html
from datetime import datetime

configs = load_configs()
faq_jsonld = "<script type='application/ld+json'>{\"foo\": \"bar\"}</script>"
html = render_post_html(
    title="Sample Title",
    body_md="# Heading\n\nSome text\n- item",
    faq_html="<section>FAQ</section>",
    faq_jsonld=faq_jsonld,
    configs=configs,
    slug="sample-post",
    published_at=datetime(2025, 1, 1)
)
start = html.index('<main>')
end = html.index('</main>', start)
main_block = html[start:end]
print(main_block)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d9739cb8fc833299dad98d85cb363b