### PR TITLE
Align sitemap location with robots.txt

### DIFF
--- a/feeds/sitemap.xml
+++ b/feeds/sitemap.xml
@@ -1,5 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
-  <url><loc>https://vladchat.github.io/site/posts/2025/09/27/introduction.html</loc><lastmod>2025-09-27</lastmod></url>
-  <url><loc>https://vladchat.github.io/site/posts/2025/09/27/introduction.html</loc><lastmod>2025-09-27</lastmod></url>
-</urlset>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://vladchat.github.io/site/feeds/sitemap.xml
+Sitemap: https://vladchat.github.io/site/sitemap.xml


### PR DESCRIPTION
## Summary
- update robots.txt to point crawlers at the root-level sitemap
- remove the outdated feeds/sitemap.xml copy so only the canonical sitemap remains

## Testing
- python rebuild_index.py

------
https://chatgpt.com/codex/tasks/task_e_68d97662a9f88332a636f93ef9f1f599